### PR TITLE
fix: create destination directory when preserve-path is true and destination doesn't exist

### DIFF
--- a/prepare_copy/main.py
+++ b/prepare_copy/main.py
@@ -32,6 +32,8 @@ def main() -> None:
         debug(f"Glob '{source}', matched {files}")
         for path in files:
             if os.path.isfile(path):
+                if preserve_path and not os.path.isdir(destination):
+                    os.makedirs(destination, exist_ok=True)
 
                 if os.path.isdir(destination):
                     if preserve_path:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,6 +168,37 @@ def test_preserve_path(monkeypatch: MonkeyPatch, mocker: MockerFixture):
     spy.assert_called_once_with("copied", [os.path.join("out", "nested", "deeper", "d.txt")])
 
 
+def test_preserve_path_creates_destination(monkeypatch: MonkeyPatch, mocker: MockerFixture):
+    """preserve-path should create the destination directory when it doesn't exist yet."""
+    def __get_input(key: str, required: bool = False):
+        if key == "source":
+            return "in/nested/c.txt"
+        elif key == "destination":
+            return "out/nested"
+        elif key == "force":
+            return False
+        elif key == "recursive":
+            return False
+        elif key == "allow-outside-working-directory":
+            return False
+        elif key == "fail-no-match":
+            return True
+        elif key == "preserve-path":
+            return True
+
+    mocker.patch('prepare_copy.main.get_input', side_effect=__get_input)
+    spy = mocker.patch("prepare_copy.main.set_output")
+    old_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tempdir:
+        monkeypatch.chdir(tempdir)
+        setup_temp(tempdir)
+        # out/nested does NOT exist — this was the bug trigger
+        main()
+        assert os.path.isdir("out/nested"), "destination should have been created as a directory"
+        monkeypatch.chdir(old_cwd)
+    spy.assert_called_once_with("copied", [os.path.join("out", "nested", "c.txt")])
+
+
 def test_common_path() -> None:
     source = "/home/solution/src/main/resources/io/github/fontysvenlo/classloader/SecretClass.class.enc"
     destination = "/home/out/assignment/src/main/resources"


### PR DESCRIPTION
When preserve-path=true and the destination path did not yet exist as a directory, the copy fell through to treating the destination as a filename, creating a file instead of copying into a directory. This caused a downstream shutil.copytree call to fail with EEXIST when a later step tried to create the same path as a directory.